### PR TITLE
Alpha sorting for prop types.

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -60,9 +60,9 @@ module.exports = {
         // Enforce propTypes declarations alphabetical sorting
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md
         'react/sort-prop-types': [2, {
-            'callbacksLast': true,
+            'callbacksLast': false,
             'ignoreCase': true,
-            'requiredFirst': true,
+            'requiredFirst': false,
         }],
         // Enforce props alphabetical sorting
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md


### PR DESCRIPTION
Fixes #8.

If we land this then we should also set `callbacksLast` to false in `react/jsx-sort-props`.