### PR TITLE
Enable react/jsx-sort-props

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -66,10 +66,10 @@ module.exports = {
         }],
         // Enforce props alphabetical sorting
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
-        // 'react/jsx-sort-props': [2, {
-        //     'ignoreCase': true,
-        //     'callbacksLast': true,
-        // }],
+        'react/jsx-sort-props': [2, {
+            'ignoreCase': true,
+            'callbacksLast': false,
+        }],
         // Validate spacing before closing bracket in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
         // 'react/jsx-space-before-closing': [2, 'always'],


### PR DESCRIPTION
Now that we are alpha-sorting our prop types, it also makes sense to purely alpha sort our props.