### PR TITLE
Enable react/jsx-handler-names.

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -26,10 +26,10 @@ module.exports = {
         // 'react/jsx-equals-spacing': [2, 'never'],
         // Enforce event handler naming conventions in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
-        // 'react/jsx-handler-names': [2, {
-        //     'eventHandlerPrefix': 'handle',
-        //     'eventHandlerPropPrefix': 'on',
-        // }],
+        'react/jsx-handler-names': [2, {
+            'eventHandlerPrefix': 'handle',
+            'eventHandlerPropPrefix': 'on',
+        }],
         // Validate props indentation in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
         'react/jsx-indent-props': [2, 4],


### PR DESCRIPTION
WIP. Don't land until ready.

Holding off on implementing this due to this rule having issues accessing listeners from arrays of objects. This rule is probably trying to be too smart, and should only care if we're accessing from `this`.