### PR TITLE
Revert to different rules for nonEmpty and selfClosing tags.

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -17,7 +17,7 @@ module.exports = {
         'react/jsx-boolean-value': [2, 'never'],
         // Validate closing bracket location in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
-        'react/jsx-closing-bracket-location': [2, 'after-props'],
+        'react/jsx-closing-bracket-location': [2, {selfClosing: 'line-aligned', nonEmpty: 'after-props'}],
         // Enforce or disallow spaces inside of curly braces in JSX attributes
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
         'react/jsx-curly-spacing': [2, 'never', { 'allowMultiline': true }],


### PR DESCRIPTION
There was some pushback on the current implementation, so reviving this config to collect feedback.