### PR TITLE
Enforce single quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
         'no-unused-expressions': 2,
         'no-unused-vars': [2, {'vars': 'all', 'args': 'none'}],
         'no-use-before-define': 2,
-        'quotes': [0, 'single'],
+        'quotes': [2, 'single'],
         'semi': [2, 'always'],
         'semi-spacing': [0, {'before': false, 'after': true}],
         'space-unary-ops': 0,


### PR DESCRIPTION
For consistency we should standardize on a quote style. The industry has essentially standardized on single quotes, for examples see both AirBnB[1] and StandardJS[2].

[1] https://github.com/airbnb/javascript/tree/master/es5#strings
[2] https://github.com/feross/standard