### PR TITLE
Add space-infix-ops.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
         'quotes': [2, 'single'],
         'semi': [2, 'always'],
         'semi-spacing': [0, {'before': false, 'after': true}],
+        'space-infix-ops': 2,
         'space-unary-ops': 0,
         'strict': 0,
         'yoda': 2,


### PR DESCRIPTION
This will ensure that we have spaces around infix operators, currently we can be quite inconsistent here.

One point of contention may be that this rule also impacts default function assignments, so we'd have to write them as:
```
var foo = function(options = {}) {
```

http://eslint.org/docs/rules/space-infix-ops

