### PR TITLE
Upgrade ESLint to latest stable (3.2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/pinterest-web/eslint-config-pinterest"
   },
   "peerDependencies": {
-    "eslint": "^2.5.3"
+    "eslint": "^3.2.2"
   },
   "dependencies": {
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
In order to use the `prefer-const` rule, we need to have at least version 3.0.0 for ESLint. This just upgrades to the most recent release according to their changelog. 

My bad for not catching this sooner 😬