### PR TITLE
Rename sort-imports to pinterest/sort-imports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
         'semi-spacing': [0, {'before': false, 'after': true}],
         'space-infix-ops': 2,
         'space-unary-ops': 0,
-        'sort-imports': ['error', {
+        'pinterest/sort-imports': ['error', {
             'ignoreCase': true,
             'ignoreMemberSort': false,
             'memberSyntaxSortOrder': ['none', 'all', 'single', 'multiple']


### PR DESCRIPTION
There is an eslint rule names sort-imports. It's conflicting with our own sort-imports linter. 