### PR TITLE
Enable react/jsx-indent, indent, react/jsx-closing-bracket-location, …

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
         'eol-last': 0,
         'eqeqeq': 2,
         'global-strict': 0,
-        'indent': 2,
+        'indent': ['error', 2, { SwitchCase: 1, VariableDeclarator: 1, outerIIFEBody: 1 }],
         'key-spacing': ["error", { "afterColon": true }],
         'keyword-spacing': ["error", { "before": true, "after": true }],
         'max-len': [2, 120, 4, {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-pinterest",
   "main": "index.js",
-  "version": "27.0.0",
+  "version": "28.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/pinterest-web/eslint-config-pinterest"

--- a/rules/react.js
+++ b/rules/react.js
@@ -49,7 +49,7 @@ module.exports = {
         'react/jsx-boolean-value': [2, 'never'],
         // Validate closing bracket location in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
-        'react/jsx-closing-bracket-location': [2, {selfClosing: 'line-aligned', nonEmpty: 'after-props'}],
+        'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
         // Enforce or disallow spaces inside of curly braces in JSX attributes
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
         'react/jsx-curly-spacing': [2, 'never', { 'allowMultiline': true }],
@@ -64,10 +64,10 @@ module.exports = {
         }],
         // Validate props indentation in JSX
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
-        'react/jsx-indent-props': [2, 4],
+        'react/jsx-indent-props': ['error', 2],
         // Validate JSX indentation
         //  https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
-        'react/jsx-indent': [2, 4],
+        'react/jsx-indent': ['error', 2],
         // Validate JSX has key prop when in array or iterator
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
         'react/jsx-key': 2,


### PR DESCRIPTION
Enable rules:
"react/jsx-indent": ['error', 2], 
"indent": ['error', 2, { SwitchCase: 1, VariableDeclarator: 1, outerIIFEBody: 1 }], 
"react/jsx-closing-bracket-location": ['error', 'line-aligned'], 
"react/jsx-indent-props": ['error', 2]