### PR TITLE
Errors for consistent-return new-cap react/jsx-no-bind

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,10 @@ module.exports = {
     parser: 'babel-eslint',
     rules: {
         'camelcase': 0,
-        'consistent-return': 1,
         'global-strict': 0,
         'max-len': [2, 120, 4, {
             "ignorePattern": "^(import\\s.+)|(\\s*(var\\s.+=\\s*)?require\\s*\\(.+)$|(jest.(un)?mock\\()"
         }],
-        'new-cap': 1,
         'no-alert': 2,
         'no-console': 2,
         'no-eq-null': 0,
@@ -54,7 +52,6 @@ module.exports = {
         'no-unsafe-finally': 0,
         'no-useless-escape': 0,
         'guard-for-in': 0,
-        'react/jsx-no-bind': 1,
         'react/no-unused-prop-types': 0,
         'react/no-find-dom-node': 0,
         'react/jsx-filename-extension': 0,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-pinterest",
   "main": "index.js",
-  "version": "59.0.0",
+  "version": "60.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/pinterest-web/eslint-config-pinterest"


### PR DESCRIPTION
Errors for `consistent-return new-cap react/jsx-no-bind`