### PR TITLE
Remove babel-eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "eslint": "^3.2.2"
   },
   "dependencies": {
-    "babel-eslint": "^6.0.0",
     "eslint-plugin-react": "^4.1.0"
   }
 }


### PR DESCRIPTION
This fixes an issue where the version of `babel-eslint` that gets installed by this module gets used in lieu of the project level `babel-eslint`.